### PR TITLE
feat: add /version to default allowed nonresource prefixes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,7 @@ type Config struct {
 	Webhook struct {
 		CertDir                    string   `mapstructure:"webhook-cert-dir" default:"config"`
 		ClusterKey                 string   `mapstructure:"webhook-cluster-key" default:"authorization.kubernetes.io/cluster-name"`
-		AllowedNonResourcePrefixes []string `mapstructure:"webhook-allowed-nonresource-prefixes" default:"/api,/openapi"`
+		AllowedNonResourcePrefixes []string `mapstructure:"webhook-allowed-nonresource-prefixes" default:"/api,/openapi,/version"`
 	} `mapstructure:",squash"`
 
 	KCP struct {


### PR DESCRIPTION
## Summary

- Add `/version` to the default list of allowed nonresource prefixes
- This permits version API calls without requiring explicit configuration