### PR TITLE
chore(ci): use @main for shared .github workflow references

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -13,7 +13,7 @@ jobs:
     concurrency:
       group: ${{ github.ref }}
       cancel-in-progress: true
-    uses: platform-mesh/.github/.github/workflows/pipeline-golang-app.yml@6fe9408e82042eca1b50ca8b065e32f769b35723 # ci/with-token-arg
+    uses: platform-mesh/.github/.github/workflows/pipeline-golang-app.yml@main
     secrets: inherit
     with:
       imageTagName: ghcr.io/platform-mesh/rebac-authz-webhook


### PR DESCRIPTION
## Summary
- Replaces SHA-pinned references to platform-mesh/.github reusable workflows with @main
- We trust our own shared actions repo and want to always follow the main branch
- This pairs with the renovate config change in platform-mesh/.github that disables digest pinning for our own repo