### PR TITLE
test: add authorization webhook fuzz tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -46,6 +46,12 @@ tasks:
       - task: test
         vars:
           ADDITIONAL_COMMAND_ARGS: -coverprofile=./cover.out -covermode=atomic
+  fuzz:
+    desc: "Run fuzz tests with a configurable duration (default 30s per target)"
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+    cmds:
+      - go test ./pkg/authorization/ -run=^$ -fuzz=FuzzWebhookServeHTTP -fuzztime={{.FUZZTIME}} -count=1
   validate:
     cmds:
       - task: lint

--- a/pkg/authorization/webhook_fuzz_test.go
+++ b/pkg/authorization/webhook_fuzz_test.go
@@ -1,0 +1,34 @@
+package authorization_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/platform-mesh/rebac-authz-webhook/pkg/authorization"
+
+	"k8s.io/klog/v2"
+)
+
+func FuzzWebhookServeHTTP(f *testing.F) {
+	f.Add([]byte(`{"apiVersion":"authorization.k8s.io/v1","kind":"SubjectAccessReview","spec":{"user":"test","resourceAttributes":{"verb":"get","resource":"pods"}}}`))
+	f.Add([]byte(`{"apiVersion":"authorization.k8s.io/v1beta1","kind":"SubjectAccessReview","spec":{"user":"test"}}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`not json`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		handler := authorization.HandlerFunc(func(_ context.Context, _ authorization.Request) authorization.Response {
+			return authorization.Allowed()
+		})
+		wh := authorization.New(klog.NewKlogr(), handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(data))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		wh.ServeHTTP(rec, req)
+	})
+}


### PR DESCRIPTION
## Summary
- Add fuzz test for the authorization webhook HTTP handler to verify it never panics on arbitrary input
- Add `task fuzz` entry to Taskfile for on-demand mutation fuzzing

Closes #243
Part of platform-mesh/backlog#231