### PR TITLE
Add OpenSSF Scorecard schedule

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,18 @@
+name: OpenSSF Scorecard
+on:
+    push:
+        branches: [main]
+    schedule:
+        - cron: '30 4 * * 1'
+    workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+    scorecard:
+        uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@main
+        permissions:
+            security-events: write
+            id-token: write
+            contents: read
+            actions: read

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 > This Repository is under development and not ready for productive use. It is in an alpha stage. That means APIs and concepts may change on short notice including breaking changes or complete removal of apis.
 
 # Platform Mesh - rebac-authz-webhook
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/rebac-authz-webhook/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/rebac-authz-webhook)
 ![Build Status](https://github.com/platform-mesh/rebac-authz-webhook/actions/workflows/pipeline.yaml/badge.svg)
 
 ## Description


### PR DESCRIPTION
Releates to https://github.com/platform-mesh/backlog/issues/227

Enables the OpenSSF Scorecard by calling a schedule workflow every monday at 4:30 AM.
Seperate Pipeline because the Scorecard should only run by pushes on main and scheduled.